### PR TITLE
Update peer dependencies to include Angular 5

### DIFF
--- a/package-dist.json
+++ b/package-dist.json
@@ -34,7 +34,7 @@
 		"lodash.clonedeep": "^4.5.0"
 	},
 	"peerDependencies": {
-		"@angular/core": "^4.2.4",
+		"@angular/core": "^4.2.4 || ^5.1.0",
 		"reflect-metadata": "^0.1.8",
 		"rxjs": "^5.4.2",
 		"zone.js": "^0.8.14"


### PR DESCRIPTION
From what I have seen in our application, there are no issues using this with Angular 5.