### PR TITLE
Create 'id' (html attribute) input property

### DIFF
--- a/src/ng-selectize.component.ts
+++ b/src/ng-selectize.component.ts
@@ -37,6 +37,7 @@ export class NgSelectizeComponent implements OnInit, OnChanges, DoCheck, Control
 	private _optgroups: any[];
 	private _optgroups_differ: IterableDiffer<any>;
 
+	@Input() id: string;
 	@Input() placeholder: string;
 	@Input() hasOptionsPlaceholder: string;
 	@Input() noOptionsPlaceholder: string;
@@ -59,6 +60,9 @@ export class NgSelectizeComponent implements OnInit, OnChanges, DoCheck, Control
 	}
 
 	ngOnInit(): void {
+		if (this.id && this.id.length > 0) {
+			this.selectizeInput.nativeElement.id = this.id;
+		}
 		this.reset();
 	}
 


### PR DESCRIPTION
Allows for the assignment of an id attribute to the selectize input. Enables focus on input by clicking on label with associated 'for' attribute. 

```
<label for="mySelectize">Clicking on this label will focus on the selectize input</label>
<ng-selectize id="mySelectize" ... etc
```